### PR TITLE
Response timeout and custom errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,5 @@ Additional work in the siyka-au repository was tested against a <b>CP1L-EM</b>.
 
 Feel free to ask questions, raise issues and make pull requests!
 
-<b>PS. Build is ok</b> but Travis is randomly failing to run tests with <b>go 1.10</b>
-(with earlier go versions tests are passed too): [travis](https://travis-ci.org/l1va/gofins)
-```
- === RUN   TestFinsClient
- 2018/03/11 18:45:18 read udp 127.0.0.1:33746->127.0.0.1:9600: use of closed network connection
- FAIL   github.com/l1va/gofins/fins	0.004s
- The command "go test -v ./..." exited with 1.
- ```
- 
  ### Thanks
  malleblas for his PR: https://github.com/l1va/gofins/pull/1

--- a/fins/client.go
+++ b/fins/client.go
@@ -4,13 +4,14 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"log"
 	"net"
 	"sync"
 	"time"
 )
+
+const DEFAULT_RESPONSE_TIMEOUT = 20 // ms
 
 // Client Omron FINS client
 type Client struct {
@@ -21,6 +22,7 @@ type Client struct {
 	src  finsAddress
 	sid  byte
 	closed bool
+	responseTimeout time.Duration
 }
 
 // NewClient creates a new Omron FINS client
@@ -28,6 +30,7 @@ func NewClient(localAddr, plcAddr Address) (*Client, error) {
 	c := new(Client)
 	c.dst = plcAddr.finsAddress
 	c.src = localAddr.finsAddress
+	c.responseTimeout = DEFAULT_RESPONSE_TIMEOUT
 
 	conn, err := net.DialUDP("udp", localAddr.udpAddress, plcAddr.udpAddress)
 	if err != nil {
@@ -40,6 +43,13 @@ func NewClient(localAddr, plcAddr Address) (*Client, error) {
 	return c, nil
 }
 
+// Set response timeout duration (ms).
+// Default value: 20ms.
+// A timeout of zero can be used to block indefinitely.
+func (c *Client) SetTimeout(t time.Duration) {
+	c.responseTimeout = t
+}
+
 // Close Closes an Omron FINS connection
 func (c *Client) Close() {
 	c.closed = true
@@ -49,7 +59,7 @@ func (c *Client) Close() {
 // ReadWords Reads words from the PLC data area
 func (c *Client) ReadWords(memoryArea byte, address uint16, readCount uint16) ([]uint16, error) {
 	if checkIsWordMemoryArea(memoryArea) == false {
-		return nil, ErrIncompatibleMemoryArea
+		return nil, &IncompatibleMemoryAreaError{memoryArea}
 	}
 	command := readCommand(memAddr(memoryArea, address), readCount)
 	r, e := c.sendCommand(command)
@@ -69,7 +79,7 @@ func (c *Client) ReadWords(memoryArea byte, address uint16, readCount uint16) ([
 // ReadBytes Reads a string from the PLC data area
 func (c *Client) ReadBytes(memoryArea byte, address uint16, readCount uint16) ([]byte, error) {
 	if checkIsWordMemoryArea(memoryArea) == false {
-		return nil, ErrIncompatibleMemoryArea
+		return nil, &IncompatibleMemoryAreaError{memoryArea}
 	}
 	command := readCommand(memAddr(memoryArea, address), readCount)
 	r, e := c.sendCommand(command)
@@ -95,7 +105,7 @@ func (c *Client) ReadString(memoryArea byte, address uint16, readCount uint16) (
 // ReadBits Reads bits from the PLC data area
 func (c *Client) ReadBits(memoryArea byte, address uint16, bitOffset byte, readCount uint16) ([]bool, error) {
 	if checkIsBitMemoryArea(memoryArea) == false {
-		return nil, ErrIncompatibleMemoryArea
+		return nil, &IncompatibleMemoryAreaError{memoryArea}
 	}
 	command := readCommand(memAddrWithBitOffset(memoryArea, address, bitOffset), readCount)
 	r, e := c.sendCommand(command)
@@ -142,7 +152,7 @@ func (c *Client) ReadClock() (*time.Time, error) {
 // WriteWords Writes words to the PLC data area
 func (c *Client) WriteWords(memoryArea byte, address uint16, data []uint16) error {
 	if checkIsWordMemoryArea(memoryArea) == false {
-		return ErrIncompatibleMemoryArea
+		return &IncompatibleMemoryAreaError{memoryArea}
 	}
 	l := uint16(len(data))
 	bts := make([]byte, 2*l, 2*l)
@@ -157,7 +167,7 @@ func (c *Client) WriteWords(memoryArea byte, address uint16, data []uint16) erro
 // WriteString Writes a string to the PLC data area
 func (c *Client) WriteString(memoryArea byte, address uint16, itemCount uint16, s string) error {
 	if checkIsWordMemoryArea(memoryArea) == false {
-		return ErrIncompatibleMemoryArea
+		return &IncompatibleMemoryAreaError{memoryArea}
 	}
 	bts := make([]byte, 2*itemCount, 2*itemCount)
 	copy(bts, s)
@@ -169,7 +179,7 @@ func (c *Client) WriteString(memoryArea byte, address uint16, itemCount uint16, 
 // WriteBits Writes bits to the PLC data area
 func (c *Client) WriteBits(memoryArea byte, address uint16, bitOffset byte, data []bool) error {
 	if checkIsBitMemoryArea(memoryArea) == false {
-		return ErrIncompatibleMemoryArea
+		return &IncompatibleMemoryAreaError{memoryArea}
 	}
 	l := uint16(len(data))
 	bts := make([]byte, 0, l)
@@ -214,7 +224,7 @@ func (c *Client) ToggleBit(memoryArea byte, address uint16, bitOffset byte) erro
 
 func (c *Client) bitTwiddle(memoryArea byte, address uint16, bitOffset byte, value byte) error {
 	if checkIsBitMemoryArea(memoryArea) == false {
-		return ErrIncompatibleMemoryArea
+		return &IncompatibleMemoryAreaError{memoryArea}
 	}
 	mem := memoryAddress{memoryArea, address, bitOffset}
 	command := writeCommand(mem, 1, []byte{value})
@@ -231,9 +241,6 @@ func checkResponse(r *response, e error) error {
 	}
 	return nil
 }
-
-// ErrIncompatibleMemoryArea Error when the memory area is incompatible with the data type to be read
-var ErrIncompatibleMemoryArea = errors.New("The memory area is incompatible with the data type to be read")
 
 func (c *Client) nextHeader() *Header {
 	sid := c.incrementSid()
@@ -259,8 +266,18 @@ func (c *Client) sendCommand(command []byte) (*response, error) {
 		return nil, err
 	}
 
-	resp := <-c.resp[header.serviceID]
-	return &resp, nil
+	// if response timeout is zero, block indefinitely
+	if c.responseTimeout > 0 {
+		select {
+		case resp := <-c.resp[header.serviceID]:
+			return &resp, nil
+		case <-time.After(c.responseTimeout * time.Millisecond):
+			return nil, &ResponseTimeoutError{c.responseTimeout}
+		}
+	} else {
+		resp := <-c.resp[header.serviceID]
+		return &resp, nil
+	}
 }
 
 func (c *Client) listenLoop() {

--- a/fins/client_test.go
+++ b/fins/client_test.go
@@ -32,7 +32,7 @@ func TestFinsClient(t *testing.T) {
 	assert.Equal(t, toWrite, vals)
 
 	// test setting response timeout
-	c.SetTimeout(50)
+	c.SetTimeoutMs(50)
 	_, err = c.ReadWords(MemoryAreaDMWord, 100, 5)
 	assert.Nil(t, err)
 }

--- a/fins/client_test.go
+++ b/fins/client_test.go
@@ -31,4 +31,8 @@ func TestFinsClient(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, toWrite, vals)
 
+	// test setting response timeout
+	c.SetTimeout(50)
+	_, err = c.ReadWords(MemoryAreaDMWord, 100, 5)
+	assert.Nil(t, err)
 }

--- a/fins/driver.go
+++ b/fins/driver.go
@@ -165,7 +165,7 @@ func encodeBCD(x uint64) []byte {
 func timesTenPlusCatchingOverflow(x uint64, digit uint64) (uint64, error) {
 	x5 := x<<2 + x
 	if int64(x5) < 0 || x5<<1 > ^digit {
-		return 0, &BCDOverflowError{}
+		return 0, BCDOverflowError{}
 	}
 	return x5<<1 + digit, nil
 }
@@ -174,7 +174,7 @@ func decodeBCD(bcd []byte) (x uint64, err error) {
 	for i, b := range bcd {
 		hi, lo := uint64(b>>4), uint64(b&0x0f)
 		if hi > 9 {
-			return 0, &BCDBadDigitError{"hi", hi}
+			return 0, BCDBadDigitError{"hi", hi}
 		}
 		x, err = timesTenPlusCatchingOverflow(x, hi)
 		if err != nil {
@@ -184,7 +184,7 @@ func decodeBCD(bcd []byte) (x uint64, err error) {
 			return x, nil
 		}
 		if lo > 9 {
-			return 0, &BCDBadDigitError{"lo", lo}
+			return 0, BCDBadDigitError{"lo", lo}
 		}
 		x, err = timesTenPlusCatchingOverflow(x, lo)
 		if err != nil {

--- a/fins/driver.go
+++ b/fins/driver.go
@@ -2,7 +2,6 @@ package fins
 
 import (
 	"encoding/binary"
-	"errors"
 )
 
 // request A FINS command request
@@ -140,9 +139,6 @@ func encodeHeader(h Header) []byte {
 	return bytes
 }
 
-var errBCDBadDigit = errors.New("Bad digit in BCD decoding")
-var errBCDOverflow = errors.New("Overflow occurred in BCD decoding")
-
 func encodeBCD(x uint64) []byte {
 	if x == 0 {
 		return []byte{0x0f}
@@ -169,7 +165,7 @@ func encodeBCD(x uint64) []byte {
 func timesTenPlusCatchingOverflow(x uint64, digit uint64) (uint64, error) {
 	x5 := x<<2 + x
 	if int64(x5) < 0 || x5<<1 > ^digit {
-		return 0, errBCDOverflow
+		return 0, &BCDOverflowError{}
 	}
 	return x5<<1 + digit, nil
 }
@@ -178,7 +174,7 @@ func decodeBCD(bcd []byte) (x uint64, err error) {
 	for i, b := range bcd {
 		hi, lo := uint64(b>>4), uint64(b&0x0f)
 		if hi > 9 {
-			return 0, errBCDBadDigit
+			return 0, &BCDBadDigitError{"hi", hi}
 		}
 		x, err = timesTenPlusCatchingOverflow(x, hi)
 		if err != nil {
@@ -188,7 +184,7 @@ func decodeBCD(bcd []byte) (x uint64, err error) {
 			return x, nil
 		}
 		if lo > 9 {
-			return 0, errBCDBadDigit
+			return 0, &BCDBadDigitError{"lo", lo}
 		}
 		x, err = timesTenPlusCatchingOverflow(x, lo)
 		if err != nil {

--- a/fins/error.go
+++ b/fins/error.go
@@ -11,7 +11,7 @@ type ResponseTimeoutError struct {
 	duration time.Duration
 }
 
-func (e *ResponseTimeoutError) Error() string {
+func (e ResponseTimeoutError) Error() string {
 	return fmt.Sprintf("Response timeout of %d has been reached", e.duration)
 }
 
@@ -19,7 +19,7 @@ type IncompatibleMemoryAreaError struct {
 	area byte
 }
 
-func (e *IncompatibleMemoryAreaError) Error() string {
+func (e IncompatibleMemoryAreaError) Error() string {
 	return fmt.Sprintf("The memory area is incompatible with the data type to be read: 0x%X", e.area)
 }
 
@@ -30,12 +30,12 @@ type BCDBadDigitError struct {
 	val uint64
 }
 
-func (e *BCDBadDigitError) Error() string {
+func (e BCDBadDigitError) Error() string {
 	return fmt.Sprintf("Bad digit in BCD decoding: %s = %d", e.v, e.val)
 }
 
 type BCDOverflowError struct {}
 
-func (e *BCDOverflowError) Error() string {
+func (e BCDOverflowError) Error() string {
 	return "Overflow occurred in BCD decoding"
 }

--- a/fins/error.go
+++ b/fins/error.go
@@ -1,0 +1,41 @@
+package fins
+
+import (
+	"fmt"
+	"time"
+)
+
+// Client errors
+
+type ResponseTimeoutError struct {
+	duration time.Duration
+}
+
+func (e *ResponseTimeoutError) Error() string {
+	return fmt.Sprintf("Response timeout of %d has been reached", e.duration)
+}
+
+type IncompatibleMemoryAreaError struct {
+	area byte
+}
+
+func (e *IncompatibleMemoryAreaError) Error() string {
+	return fmt.Sprintf("The memory area is incompatible with the data type to be read: 0x%X", e.area)
+}
+
+// Driver errors
+
+type BCDBadDigitError struct {
+	v string
+	val uint64
+}
+
+func (e *BCDBadDigitError) Error() string {
+	return fmt.Sprintf("Bad digit in BCD decoding: %s = %d", e.v, e.val)
+}
+
+type BCDOverflowError struct {}
+
+func (e *BCDOverflowError) Error() string {
+	return "Overflow occurred in BCD decoding"
+}


### PR DESCRIPTION
1. Implement a response timeout for client commands. Default value of 20ms.
Can be changed using SetTimeout(t). Value of zero will block.
2. Use custom error types instead of errors.New.. so that library users will be able to
do better error handling. Definitions are in errors.go.
3. Removed a bit from README about Travis failing tests